### PR TITLE
Fix: Make sure that Skytap XBlock handles successful "Launch" requests correctly.

### DIFF
--- a/tests/unit/mixins/boomi.py
+++ b/tests/unit/mixins/boomi.py
@@ -36,7 +36,7 @@ class CreateVmMockMixin(unittest.TestCase):
         Mock a successful response from the createVm endpoint.
         """
         response = {
-            "ErrorExists": False,
+            "ErrorExists": 'false',  # Boomi does not support Boolean values in JSON responses.
             "ErrorMessage": None,
             "SkytapURL": sharing_portal_url,
         }
@@ -53,7 +53,7 @@ class CreateVmMockMixin(unittest.TestCase):
         Mock an error response from the createVm endpoint.
         """
         response = {
-            "ErrorExists": True,
+            "ErrorExists": 'true',  # Boomi does not support Boolean values in JSON responses.
             "ErrorMessage": error,
             "SkytapURL": None,
         }

--- a/tests/unit/test_skytap.py
+++ b/tests/unit/test_skytap.py
@@ -58,11 +58,10 @@ class TestSkytap(CreateVmMockMixin):
 
         self.block = SkytapXBlock(self.runtime_mock, DictFieldData({}), self.scope_ids_mock)
 
-    def assert_launch_response(self, expected, code=500, settings=XBLOCK_SETTINGS):
+    def assert_launch_response(self, expected, code=500):
         """
         Helper method for calling the launch method and asserting an expected response dict.
         """
-        self.block.get_xblock_settings = Mock(return_value=settings)
         response = self.block.launch(request=Mock(method='POST', body=json.dumps('de')))
 
         self.assertEqual(response.status_code, code)
@@ -184,7 +183,7 @@ class TestSkytap(CreateVmMockMixin):
         Test that a malformed response from Boomi will result in a generic error message being returned to the client.
         """
         self.block.get_xblock_settings = Mock(return_value={})
-        self.assert_launch_response({u'error': u'The Skytap XBlock is improperly configured.'}, code=500, settings={})
+        self.assert_launch_response({u'error': u'The Skytap XBlock is improperly configured.'}, code=500)
 
     def test_launch_no_runtime_user(self):
         """

--- a/tests/unit/test_skytap.py
+++ b/tests/unit/test_skytap.py
@@ -180,7 +180,7 @@ class TestSkytap(CreateVmMockMixin):
 
     def test_launch_improperly_configured(self):
         """
-        Test that a malformed response from Boomi will result in a generic error message being returned to the client.
+        Test that launch method gracefully fails if Boomi configuration is missing or invalid.
         """
         self.block.get_xblock_settings = Mock(return_value={})
         self.assert_launch_response({u'error': u'The Skytap XBlock is improperly configured.'}, code=500)

--- a/xblock_skytap/skytap.py
+++ b/xblock_skytap/skytap.py
@@ -254,7 +254,11 @@ class SkytapXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
             )
             self.raise_error(self._('The Skytap launch service returned a malformed response.'), exception=True)
 
-        if response_json['ErrorExists']:
+        # Check if Boomi encountered an error while processing the request,
+        # and pass it back to the client.
+        # Note that Boomi does not support Boolean values in JSON responses,
+        # so the check needs to compare string values.
+        if response_json['ErrorExists'].lower() == 'true':
             self.raise_error(response_json['ErrorMessage'])
 
         return {


### PR DESCRIPTION
Part of the scope of [OC-2506](https://tasks.opencraft.com/browse/OC-2506).

Boomi can't set Boolean values in JSON responses, so this PR adapts how the Skytap XBlock checks whether Boomi reported an error.

**Reviewers**

- [x] @haikuginger 