### PR TITLE
Fix: Make sure Skytap XBlock can access translation service.

### DIFF
--- a/xblock_skytap/skytap.py
+++ b/xblock_skytap/skytap.py
@@ -58,6 +58,7 @@ DEFAULT_KEYBOARD_LAYOUTS = {  # Sorted by language code
 
 @XBlock.wants("settings")
 @XBlock.wants("user")
+@XBlock.needs("i18n")
 class SkytapXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
     """
     An XBlock that allows learners to access a Skytap (https://www.skytap.com/) environment for a given course.


### PR DESCRIPTION
Part of the scope of [OC-2506](https://tasks.opencraft.com/browse/OC-2506).

**Test instructions**

0. Make sure Skytap XBlock does not attempt to send any requests to Boomi by, e.g., changing

    ```python
        current_user = self.get_current_user()
    ```

    to

    ```python
        current_user = None
    ```

    in [skytap.py](https://github.com/open-craft/xblock-skytap/blob/master/xblock_skytap/skytap.py#L221).

1. Add Skytap XBlock to a unit.

2. Navigate to unit containing Skytap XBlock in the LMS and click "Launch". Observe that:

    * Block displays "Error: An unknown error occurred while launching.".

    * Server log contains traceback ending with `NoSuchServiceError: Service 'i18n' was not requested.`

3. Stash changes to [skytap.py](https://github.com/open-craft/xblock-skytap/blob/master/xblock_skytap/skytap.py#L221) from earlier, check out this branch (`fix-i18n`), re-apply changes from earlier by popping stash.

4. Restart LMS.

5. Navigate to unit containing Skytap XBlock in the LMS and click "Launch". Observe that:

    * Block correctly displays "Error: Unable to fetch the current user from the runtime.".

    * Server log contains the same error and reports an HTTP `500` for the `launch` handler:

        ```
        2017-04-26 06:04:46,853 ERROR 20968 [xblock_skytap.skytap] skytap.py:210 - Unable to fetch the current user from the runtime.
        [26/Apr/2017 06:04:46] "POST /courses/course-v1:OpenCraft+ISX101+2017/xblock/block-v1:OpenCraft+ISX101+2017+type@skytap+block@bc702d1f14954698957b45732dfd491d/handler/launch HTTP/1.1" 500 63
        ```

    * Server log does *not* contain traceback indicating server-side error.

**Reviewers**

- [x] @bdero 