### PR TITLE
Fix client-side code that reads sharing portal URL from server's response

### DIFF
--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -21,7 +21,7 @@ function SkytapXBlock(runtime, element) {
 
         launchXHR = $.post(handlerUrl, JSON.stringify(keyboardLayout))
             .success(function(response) {
-                var url = response.responseJSON.sharing_portal_url;
+                var url = response.sharing_portal_url;
                 var sharingPortal = window.open(url, '_blank');
                 if (sharingPortal === null) {
                     alert("The browser's popup blocker prevented the exercise environment from being launched.");


### PR DESCRIPTION
Part of the scope of [OC-2506](https://tasks.opencraft.com/browse/OC-2506).

**Test instructions**

0. Modify `launch` handler to return fake URL to prepare for testing how client-side code behaves on success: Insert

    ```python
        return {
            'sharing_portal_url': 'http://example.com'
        }
    ```

    above

    ```python
        # Fetch the sharing portal URL from Boomi
        response = requests.post(...)
    ```

    in [skytap.py](https://github.com/open-craft/xblock-skytap/blob/master/xblock_skytap/skytap.py#L236-L237).

1. Add Skytap XBlock to a unit.

2. Open browser console.

3. Navigate to unit containing Skytap XBlock in the LMS and click "Launch". Observe that browser does not open fake URL in new tab, and that browser console contains the following error:

    > Uncaught TypeError: Cannot read property 'sharing_portal_url' of undefined

4. Stash changes to [skytap.py](https://github.com/open-craft/xblock-skytap/blob/master/xblock_skytap/skytap.py#L236-L237) from earlier, check out this branch (`fix-client-success`), re-apply changes from earlier by popping stash.

5. Restart LMS.

6. Navigate to unit containing Skytap XBlock in the LMS and click "Launch". Observe that browser opens fake URL in new tab, and that console does not contain error mentioned above.

**Reviewers**

- [x] @bdero 