### PR TITLE
Incorporate feedback from QA

### DIFF
--- a/tests/integration/test_skytap.py
+++ b/tests/integration/test_skytap.py
@@ -41,17 +41,29 @@ class TestSkytap(StudioEditableBaseTest):
         """
         self.browser.execute_script("$(document).html(' ');")
 
-    def find_menu(self):
+    def find_menu(self, index):
         """
-        Locate menu for selecting keyboard layout and return it.
+        Locate menu for selecting keyboard layout that sits at `index` in the list of menus and return it.
         """
-        return Select(self.element.find_element_by_tag_name("select"))
+        return self.find_menus()[index]
 
-    def find_launch_button(self):
+    def find_menus(self):
         """
-        Locate button for launching exercise environment and return it.
+        Locate menus for selecting keyboard layout and return them.
         """
-        return self.element.find_element_by_css_selector(".skytap-launch")
+        return [Select(menu) for menu in self.element.find_elements_by_tag_name("select")]
+
+    def find_launch_button(self, index):
+        """
+        Locate button for launching exercise environment that sits at `index` in the list of buttons and return it.
+        """
+        return self.find_launch_buttons()[index]
+
+    def find_launch_buttons(self):
+        """
+        Locate buttons for launching exercise environment and return them.
+        """
+        return self.element.find_elements_by_css_selector(".skytap-launch")
 
     def find_spinner(self):
         """
@@ -90,22 +102,26 @@ class TestSkytap(StudioEditableBaseTest):
         - When accessing Skytap XBlock instance for the first time,
           menu should default to "English (US)".
         - On subsequent visits, menu should default to keyboard layout that
-          was selected when learner last clicked button for launching exercise environment.
+          was selected when learner last clicked button for launching exercise environment,
+          across different instances of the Skytap XBlock.
         """
-        self.load_scenario("xml/skytap_defaults.xml")
+        self.load_scenario("xml/skytap_multiple.xml")
 
-        menu = self.find_menu()
-        self.assert_selected_option(menu, "us", "English (US)")
+        menus = self.find_menus()
+        for menu in menus:
+            self.assert_selected_option(menu, "us", "English (US)")
 
+        menu = self.find_menu(0)
         menu.select_by_visible_text("Norwegian")
 
-        launch_button = self.find_launch_button()
+        launch_button = self.find_launch_button(0)
         launch_button.click()
 
-        self.refresh_page()
+        self.load_scenario("xml/skytap_multiple.xml")
 
-        menu = self.find_menu()
-        self.assert_selected_option(menu, "no", "Norwegian")
+        menus = self.find_menus()
+        for menu in menus:
+            self.assert_selected_option(menu, "no", "Norwegian")
 
     @patch('xblock_skytap.SkytapXBlock.get_boomi_url')
     @patch('xblock_skytap.SkytapXBlock.get_current_course')
@@ -118,7 +134,7 @@ class TestSkytap(StudioEditableBaseTest):
 
         self.load_scenario("xml/skytap_defaults.xml")
 
-        launch_button = self.find_launch_button()
+        launch_button = self.find_launch_button(0)
         spinner = self.find_spinner()
 
         def mock_post(*args, **kwargs):

--- a/tests/integration/test_skytap.py
+++ b/tests/integration/test_skytap.py
@@ -47,7 +47,7 @@ class TestSkytap(StudioEditableBaseTest):
 
     def find_launch_button(self):
         """
-        Locate "Launch" button and return it.
+        Locate button for launching exercise environment and return it.
         """
         return self.element.find_element_by_css_selector(".skytap-launch")
 
@@ -82,7 +82,7 @@ class TestSkytap(StudioEditableBaseTest):
         - When accessing Skytap XBlock instance for the first time,
           menu should default to "English (US)".
         - On subsequent visits, menu should default to keyboard layout that
-          was selected when learner last clicked "Launch" button.
+          was selected when learner last clicked button for launching exercise environment.
         """
         self.load_scenario("xml/skytap_defaults.xml")
 

--- a/tests/integration/xml/skytap_multiple.xml
+++ b/tests/integration/xml/skytap_multiple.xml
@@ -1,0 +1,4 @@
+<vertical_demo>
+  <skytap url_name="first_block" />
+  <skytap url_name="second_block" />
+</vertical_demo>

--- a/xblock_skytap/public/css/skytap.css
+++ b/xblock_skytap/public/css/skytap.css
@@ -20,6 +20,10 @@
     border: 1px solid #d2c9c9;
 }
 
+.skytap-block .skytap-action i.skytap-spinner {
+    margin-left: 0.8em;
+}
+
 .skytap-block .skytap-error {
     color: darkred;
 }

--- a/xblock_skytap/public/css/skytap.css
+++ b/xblock_skytap/public/css/skytap.css
@@ -1,11 +1,34 @@
-.skytap-block h3, .skytap-block label {
-    margin-bottom: 1em;
+.skytap-block h3,
+.skytap-block label,
+.skytap-block .skytap-action,
+.skytap-block .skytap-error {
+    margin-bottom: 1.4em;
 }
 
 .skytap-block label {
     display: block;
 }
 
+.skytap-block .skytap-action button.skytap-launch:focus {
+    box-shadow: inset 0 0 8px 4px #cac2c2, inset 0 0 8px 4px #cac2c2;
+}
+
+.skytap-block .skytap-action button.skytap-launch:hover {
+    box-shadow: inset 0 1px 0 0 #fefefe;
+    background-color: #e4e4e4;
+    text-shadow: 0 1px 0 #fcfbfb;
+    border: 1px solid #d2c9c9;
+}
+
 .skytap-block .skytap-error {
     color: darkred;
+}
+
+.skytap-block .additional-info p {
+    margin-bottom: 0.4em;
+    font-style: italic;
+}
+
+.skytap-block .additional-info p+p {
+    margin-top: 0.5em;
 }

--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -5,8 +5,13 @@ function SkytapXBlock(runtime, element) {
 
     var launchForm = $('.skytap-launch-form', element),
         launchButton = launchForm.find('.skytap-launch'),
+        launchSpinner = launchForm.find('.skytap-spinner'),
         launchXHR;
 
+    // Prepare UI
+    launchSpinner.hide();
+
+    // Set up click handler for button that allows learners to launch exercise environment
     launchButton.on('click', function(e) {
         e.preventDefault();
 
@@ -17,7 +22,8 @@ function SkytapXBlock(runtime, element) {
             launchXHR.abort();
         }
 
-        launchButton[0].setAttribute('disabled', 'true');
+        launchSpinner.show();
+        launchButton.prop('disabled', true);
 
         launchXHR = $.post(handlerUrl, JSON.stringify(keyboardLayout))
             .success(function(response) {
@@ -28,8 +34,6 @@ function SkytapXBlock(runtime, element) {
                 } else {
                     sharingPortal.focus();
                 }
-
-                launchButton[0].removeAttribute('disabled');
             })
             .error(function(jqXHR, textStatus, errorThrown) {
                 var error;
@@ -39,8 +43,10 @@ function SkytapXBlock(runtime, element) {
                     error = 'An unknown error occurred while launching.';
                 }
                 $('#skytap-error-message').text('Error: ' + error);
-
-                launchButton[0].removeAttribute('disabled');
+            })
+            .complete(function() {
+                launchSpinner.hide();
+                launchButton.prop('disabled', false);
             });
 
     });

--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -3,6 +3,12 @@
 function SkytapXBlock(runtime, element) {
     "use strict";
 
+    // Set up gettext in case it isn't available in the client runtime:
+    if (typeof gettext == 'undefined') {
+        window.gettext = function gettext_stub(string) { return string; };
+        window.ngettext = function ngettext_stub(strA, strB, n) { return n == 1 ? strA : strB; };
+    }
+
     var launchForm = $('.skytap-launch-form', element),
         launchButton = launchForm.find('.skytap-launch'),
         launchSpinner = launchForm.find('.skytap-spinner'),
@@ -30,7 +36,9 @@ function SkytapXBlock(runtime, element) {
                 var url = response.sharing_portal_url;
                 var sharingPortal = window.open(url, '_blank');
                 if (sharingPortal === null) {
-                    alert("The browser's popup blocker prevented the exercise environment from being launched.");
+                    alert(
+                        gettext("The browser's popup blocker prevented the exercise environment from being launched.")
+                    );
                 } else {
                     sharingPortal.focus();
                 }
@@ -40,7 +48,7 @@ function SkytapXBlock(runtime, element) {
                 if (jqXHR.hasOwnProperty('responseJSON') && jqXHR.responseJSON.hasOwnProperty('error')) {
                     error = jqXHR.responseJSON.error;
                 } else {
-                    error = 'An unknown error occurred while launching.';
+                    error = gettext('An unknown error occurred while launching.');
                 }
                 $('#skytap-error-message').text('Error: ' + error);
             })

--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -38,7 +38,7 @@ function SkytapXBlock(runtime, element) {
                 } else {
                     error = 'An unknown error occurred while launching.';
                 }
-                $('#skytap-error').text('Error: ' + error);
+                $('#skytap-error-message').text('Error: ' + error);
 
                 launchButton[0].removeAttribute('disabled');
             });

--- a/xblock_skytap/skytap.py
+++ b/xblock_skytap/skytap.py
@@ -68,7 +68,7 @@ class SkytapXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
 
     display_name = String(
         display_name=_("Title"),
-        help=_("The title of this block. Displayed above the controls for launching the exercise environment."),
+        help=_("The title of this block. Learners currently don't see this."),
         scope=Scope.settings,
         default=_("Skytap XBlock"),
     )

--- a/xblock_skytap/skytap.py
+++ b/xblock_skytap/skytap.py
@@ -76,7 +76,7 @@ class SkytapXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
     # User state
 
     preferred_keyboard_layout = String(
-        scope=Scope.user_state,
+        scope=Scope.preferences,
         default="us",
     )
 

--- a/xblock_skytap/templates/skytap.html
+++ b/xblock_skytap/templates/skytap.html
@@ -19,6 +19,7 @@
       <button type="button" class="skytap-launch">
         {% trans "Open" %}
       </button>
+      <i class="fa fa-spinner fa-spin skytap-spinner" aria-hidden="true"></i>
     </div>
     <div class="skytap-error">
       <span id="skytap-error-message" aria-live="assertive"></span>

--- a/xblock_skytap/templates/skytap.html
+++ b/xblock_skytap/templates/skytap.html
@@ -1,9 +1,10 @@
+{% load i18n %}
 <div class="skytap-block">
-  <h3>{{ display_name }}</h3>
+  <h3>{% trans "Open the Exercise Environment Portal" %}</h3>
   <form class="skytap-launch-form">
     <div>
       <label>
-        <span>Select your preferred keyboard layout:</span>
+        <span>{% trans "Select your preferred keyboard layout" %}:</span>
         <select name="keyboard_layout">
           {% for language_code, language_name in keyboard_layouts %}
             <option value="{{ language_code }}"
@@ -14,11 +15,21 @@
         </select>
       </label>
     </div>
-    <div>
-      <input class="skytap-launch" type="submit" name="submit" value="Launch">
+    <div class="skytap-action">
+      <button type="button" class="skytap-launch">
+        {% trans "Open" %}
+      </button>
     </div>
-    <div>
-      <span id="skytap-error" class="skytap-error" aria-live="assertive"></span>
+    <div class="skytap-error">
+      <span id="skytap-error-message" aria-live="assertive"></span>
+    </div>
+    <div class="additional-info">
+      <p>
+        {% trans "Don't forget to suspend or shut down your VMs when you are done using them!" %}
+      </p>
+      <p>
+        {% trans "If you are having issues accessing your exercise environment, please contact" %} <a href="mailto:ondemand-feedback@cloudera.com">ondemand-feedback@cloudera.com</a>.
+      </p>
     </div>
   </form>
 </div>


### PR DESCRIPTION
cf. [OC-2611](https://tasks.opencraft.com/browse/OC-2611)

**Test instructions**: UI changes

1. Create two sections with one subsection and one unit each.

2. Add an instance of the Skytap XBlock to each of the units.

3. Access one of the units in the LMS and verify the following changes:
    * Heading at the top says "Open the Exercise Environment Portal" (instead of "Skytap XBlock").
    * Button for launching exercise environment says "Open" (instead of "Launch").
    * Vertical space between heading, keyboard field, and button is larger than before.
    * Block shows additional information at bottom:
        > Don't forget to suspend or shut down your VMs when you are done using them!
        > If you are having issues accessing your exercise environment, please contact ondemand-feedback@cloudera.com.

**Test instructions**: Spinner

1. Introduce a small delay to the `launch` handler, to make it easier to observe UI updates while requests are in progress: Insert `import time; time.sleep(5)` at the beginning of the method.

2. *Happy path*: Modify `launch` handler to return fake URL to prepare for testing how client-side code behaves on success. Insert

    ```python
        return {
            'sharing_portal_url': 'http://example.com'
        }
    ```

    above

    ```python
        # Fetch the sharing portal URL from Boomi
        response = requests.post(...)
    ```

    in [skytap.py](https://github.com/open-craft/xblock-skytap/blob/master/xblock_skytap/skytap.py#L236-L237).

3. Access unit containing Skytap XBlock in the LMS and click "Open". Observe that animated spinner next to "Open" button becomes visible, spins for the duration of the request, and is hidden once the request completes.

4. *Sad path*: Modify `launch` handler to return an error. Replace

    ```python
        return {
            'sharing_portal_url': 'http://example.com'
        }
    ```

    with

    ```python
        self.raise_error(self._('The Skytap launch service returned a malformed response.'), exception=True)
    ```

5. Access unit containing Skytap XBlock in the LMS and click "Open". Observe that animated spinner next to "Open" button becomes visible, spins for the duration of the request, and is hidden once the request completes.

**Test instructions**: Preferred keyboard layout

With the changes for keeping the `launch` handler from contacting Boomi still in place:

1. Access first unit containing Skytap XBlock in the LMS, select a non-default keyboard layout, and click "Open".

2. Refresh the page. Observe that the keyboard layout option now defaults to the keyboard layout option you selected in the previous step. (This is existing behavior.)

3. Navigate to second unit containing Skytap XBlock in the LMS. Observe that the keyboard layout option also defaults to the option you selected two steps prior.

**Reviewers**

- [x] @bdero 