### PR TITLE
Fix launch behaviour for iOS devices

### DIFF
--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -37,13 +37,16 @@ function SkytapXBlock(runtime, element) {
 
                 /*
                  The standard behaviour is to open the exercise environment in a new tab using a popup,
-                 to allow the user to keep the course tab open too. However on iOS devices, popups are
-                 blocked by default and the user is not informed that the popup failed to open.
-                 Therefore for iOS devices a redirect is used instead.
+                 to allow the user to keep the course tab open too. However on iOS devices for example,
+                 popups are blocked by default and the user is not informed that the popup failed to open.
+                 Therefore for iOS devices a redirect is used instead. For consistency this is done for all
+                 mobile devices.
                  */
-                var iOS = navigator.userAgent.match(/(iPod|iPhone|iPad)/);
-                if (iOS) {
-                    // simply redirect for mobile Safari
+                var isiOS = navigator.userAgent.match(/(iPod|iPhone|iPad)/i);
+                var isAndroid = navigator.userAgent.match(/(android)/i);
+                var isWindows = navigator.userAgent.match(/(Windows Phone|iemobile)/i);
+                if (isiOS || isAndroid || isWindows) {
+                    // simply redirect for mobile devices
                     window.location = url;
                 } else {
                     // desktop browsers offer an easy way to allow the popup so being blocked is ok

--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -52,7 +52,7 @@ function SkytapXBlock(runtime, element) {
                     // Desktop browsers offer an easy way to allow the popup so being blocked is ok.
                     var sharingPortal = window.open(url, '_blank');
                     if (sharingPortal === undefined || sharingPortal === null) {
-                        // Use '==' instead of '===' to test for both null (from desktop browsers blocking the popup)
+                        // Need to test for both null (from desktop browsers blocking the popup)
                         // and also undefined (from mobile Safari refusing to show the popup).
                         alert(gettext("The browser's popup blocker prevented the exercise environment from being launched."));
                     } else {

--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -34,13 +34,29 @@ function SkytapXBlock(runtime, element) {
         launchXHR = $.post(handlerUrl, JSON.stringify(keyboardLayout))
             .success(function(response) {
                 var url = response.sharing_portal_url;
-                var sharingPortal = window.open(url, '_blank');
-                if (sharingPortal === null) {
-                    alert(
-                        gettext("The browser's popup blocker prevented the exercise environment from being launched.")
-                    );
+
+                /*
+                 The standard behaviour is to open the exercise environment in a new tab using a popup,
+                 to allow the user to keep the course tab open too. However on iOS devices, popups are
+                 blocked by default and the user is not informed that the popup failed to open.
+                 Therefore for iOS devices a redirect is used instead.
+                 */
+                var iOS = navigator.userAgent.match(/(iPod|iPhone|iPad)/);
+                if (iOS) {
+                    // simply redirect for mobile Safari
+                    window.location = url;
                 } else {
-                    sharingPortal.focus();
+                    // desktop browsers offer an easy way to allow the popup so being blocked is ok
+                    var sharingPortal = window.open(url, '_blank');
+                    if (sharingPortal == null) {
+                        // use '==' instead of '===' to test for both null (from desktop browsers blocking the popup)
+                        // and also undefined (from mobile Safari refusing to show the popup)
+                        alert(
+                            gettext("The browser's popup blocker prevented the exercise environment from being launched.")
+                        );
+                    } else {
+                        sharingPortal.focus();
+                    }
                 }
             })
             .error(function(jqXHR, textStatus, errorThrown) {

--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -46,17 +46,15 @@ function SkytapXBlock(runtime, element) {
                 var isAndroid = navigator.userAgent.match(/(android)/i);
                 var isWindows = navigator.userAgent.match(/(Windows Phone|iemobile)/i);
                 if (isiOS || isAndroid || isWindows) {
-                    // simply redirect for mobile devices
+                    // Simply redirect for mobile devices.
                     window.location = url;
                 } else {
-                    // desktop browsers offer an easy way to allow the popup so being blocked is ok
+                    // Desktop browsers offer an easy way to allow the popup so being blocked is ok.
                     var sharingPortal = window.open(url, '_blank');
-                    if (sharingPortal == null) {
-                        // use '==' instead of '===' to test for both null (from desktop browsers blocking the popup)
-                        // and also undefined (from mobile Safari refusing to show the popup)
-                        alert(
-                            gettext("The browser's popup blocker prevented the exercise environment from being launched.")
-                        );
+                    if (sharingPortal === undefined || sharingPortal === null) {
+                        // Use '==' instead of '===' to test for both null (from desktop browsers blocking the popup)
+                        // and also undefined (from mobile Safari refusing to show the popup).
+                        alert(gettext("The browser's popup blocker prevented the exercise environment from being launched."));
                     } else {
                         sharingPortal.focus();
                     }


### PR DESCRIPTION
This PR fixes [https://tasks.opencraft.com/browse/OC-2700](https://tasks.opencraft.com/browse/OC-2700).

The SkyTab XBlock did not work for iOS devices because the launch method used a popup to display the boomi instance. This is blocked by default on iOS and but mobile Safari does not notify users or give them an easy way to allow popups without changing a setting globally. Therefore the solution is to redirect rather than attempt to open a new tab.

**Some notes**
* The current code only redirects iOS devices - I tested both Firefox and Chrome on android and both allow users to block the popup in a similar manner to desktop browsers.
* There may be a better solution than user agent sniffing however this seems to be the most widely accepted method to detect mobile safari. If the user agent sniffing fails, the user will at least get an alert telling them the popup was blocked - that was previously not correctly working on iOS either.
* I was not able to create a test for this as the selenium tests cannot fake user agent easily. 

**Test Instructions**
 ( partly borrowed from https://github.com/open-craft/xblock-skytap/pull/6 :-) )

* Modify launch handler to return fake URL to prepare for testing how client-side code behaves on success: Insert
```
    return {
        'sharing_portal_url': 'http://example.com'
    }
```
above
```
            try:
            boomi_url = self.get_boomi_url()
```
in skytap.py.

* Add Skytap XBlock to a unit.

* Old behaviour, on the open-craft:xblock-skytap master branch:  Using an iOS device or simulator, navigate to the unit containing the Skytap XBlock in LMS and click "Launch".  There will be a spinner but nothing will happen, no warnings or errors.

* Fixed behaviour: Install the carlio:xblock-skytap fork master branch into the LMS virtualenv instead and restart it. Perform the same steps. This time, the safari browser will open the example URL in the same tab.
