### PR TITLE
Migrate to CircleCI v2

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,22 +1,37 @@
-machine:
-  python:
-    version: 2.7.10
-dependencies:
-  override:
-    - "pip install -U pip wheel"
-    # Temporarily pin setuptools to a specific version.
-    # See commit message of https://github.com/open-craft/problem-builder/commit/51277a34fb426724616618c1afdb893ab2de4c6b for more info:
-    - "pip install setuptools==24.3.1"
-    - "pip install -r requirements.txt"
-    - "pip install -r test-requirements.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/base.txt"
-    - "pip install -r $VIRTUAL_ENV/src/xblock-sdk/requirements/test.txt"
-    - "pip install -e ."
-    - "mkdir var"
-test:
-  override:
-    - "pep8 xblock_skytap --max-line-length=120"
-    - "pep8 tests --max-line-length=120"
-    - "pylint xblock_skytap --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable"
-    - "pylint tests --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable"
-    - "SELENIUM_BROWSER=chrome python run_tests.py"
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/python:2.7.14-browsers
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+      - run:
+          name: Install Python deps in a venv
+          command: |
+            virtualenv venv
+            . venv/bin/activate
+            pip install -U pip wheel
+            # Temporarily pin setuptools to a specific version.
+            # See commit message of https://github.com/open-craft/problem-builder/commit/51277a34fb426724616618c1afdb893ab2de4c6b for more info:
+            pip install setuptools==24.3.1
+            pip install -r requirements.txt
+            pip install -r test-requirements.txt
+            pip install -r venv/src/xblock-sdk/requirements/base.txt
+            pip install -r venv/src/xblock-sdk/requirements/test.txt
+            pip install -e .
+            mkdir var
+      - save_cache:
+          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+          paths:
+            - "venv"
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            pep8 xblock_skytap --max-line-length=120;
+            pep8 tests --max-line-length=120;
+            pylint xblock_skytap --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable;
+            pylint tests --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable;
+            SELENIUM_BROWSER=chrome python run_tests.py


### PR DESCRIPTION
Migrating to CircleCI version 2.

JIRA Ticket: OC-4151

Testing instructions:

Check that tests are passing.

Note to reviewer:

Added Cache, so that it doesn't have to install requirements each time.
Using browsers image, comes with Chrome pre-installed

Reviewers:

[Sven]