### PR TITLE
Removed the keyboard input element from the template.

### DIFF
--- a/tests/integration/test_skytap.py
+++ b/tests/integration/test_skytap.py
@@ -8,7 +8,6 @@ import time
 
 from mock import Mock, patch
 
-from selenium.webdriver.support.select import Select
 from selenium.webdriver.support.ui import WebDriverWait
 
 from xblockutils.resources import ResourceLoader
@@ -41,18 +40,6 @@ class TestSkytap(StudioEditableBaseTest):
         """
         self.browser.execute_script("$(document).html(' ');")
 
-    def find_menu(self, index):
-        """
-        Locate menu for selecting keyboard layout that sits at `index` in the list of menus and return it.
-        """
-        return self.find_menus()[index]
-
-    def find_menus(self):
-        """
-        Locate menus for selecting keyboard layout and return them.
-        """
-        return [Select(menu) for menu in self.element.find_elements_by_tag_name("select")]
-
     def find_launch_button(self, index):
         """
         Locate button for launching exercise environment that sits at `index` in the list of buttons and return it.
@@ -84,44 +71,6 @@ class TestSkytap(StudioEditableBaseTest):
         """
         tab = self.driver.window_handles[index]
         self.driver.switch_to.window(tab)
-
-    def assert_selected_option(self, menu, expected_value, expected_text):
-        """
-        Assert that selected option from `menu` matches `expected_value` and `expected_text`.
-        """
-        selected_option = menu.first_selected_option
-        selected_option_value = selected_option.get_attribute("value")
-        selected_option_text = selected_option.text.strip()
-        self.assertEqual(selected_option_value, expected_value)
-        self.assertEqual(selected_option_text, expected_text)
-
-    def test_keyboard_layouts(self):
-        """
-        Test that menu for selecting keyboard layout defaults to appropriate value.
-
-        - When accessing Skytap XBlock instance for the first time,
-          menu should default to "English (US)".
-        - On subsequent visits, menu should default to keyboard layout that
-          was selected when learner last clicked button for launching exercise environment,
-          across different instances of the Skytap XBlock.
-        """
-        self.load_scenario("xml/skytap_multiple.xml")
-
-        menus = self.find_menus()
-        for menu in menus:
-            self.assert_selected_option(menu, "us", "English (US)")
-
-        menu = self.find_menu(0)
-        menu.select_by_visible_text("Norwegian")
-
-        launch_button = self.find_launch_button(0)
-        launch_button.click()
-
-        self.load_scenario("xml/skytap_multiple.xml")
-
-        menus = self.find_menus()
-        for menu in menus:
-            self.assert_selected_option(menu, "no", "Norwegian")
 
     @patch('xblock_skytap.SkytapXBlock.get_boomi_url')
     @patch('xblock_skytap.SkytapXBlock.get_current_course')

--- a/tests/unit/test_skytap.py
+++ b/tests/unit/test_skytap.py
@@ -13,7 +13,7 @@ from mock import Mock
 from xblock.field_data import DictFieldData
 
 from xblock_skytap.exceptions import BoomiConfigurationInvalidError, BoomiConfigurationMissingError
-from xblock_skytap.skytap import DEFAULT_KEYBOARD_LAYOUTS, SkytapXBlock
+from xblock_skytap.skytap import SkytapXBlock
 
 from .mixins.boomi import BOOMI_CONFIGURATION, CreateVmMockMixin
 
@@ -22,13 +22,6 @@ from .mixins.boomi import BOOMI_CONFIGURATION, CreateVmMockMixin
 
 XBLOCK_SETTINGS = {
     "boomi_configuration": BOOMI_CONFIGURATION,
-    "keyboard_layouts": {
-        "de": "German",
-        "de-ch": "German-Switzerland",
-        "es": "Spanish",
-        "fi": "Finnish",
-        "fr": "French",
-    },
 }
 
 
@@ -66,59 +59,6 @@ class TestSkytap(CreateVmMockMixin):
 
         self.assertEqual(response.status_code, code)
         self.assertDictEqual(response.json, expected)
-
-    def test_get_keyboard_layouts_no_settings(self):
-        """
-        Test that `get_keyboard_layouts` returns default value
-        if settings service is not available.
-        """
-        self.runtime_mock.service = Mock(return_value=None)
-        self.assertEqual(self.block.get_keyboard_layouts(), DEFAULT_KEYBOARD_LAYOUTS)
-
-    def test_get_keyboard_layouts_no_customizations(self):
-        """
-        Test that `get_keyboard_layouts` returns default value
-        if XBLOCK_SETTINGS do not include customizations for Skytap XBlock.
-        """
-        self.block.get_xblock_settings = Mock(return_value=None)
-        self.assertEqual(self.block.get_keyboard_layouts(), DEFAULT_KEYBOARD_LAYOUTS)
-        self.block.get_xblock_settings.assert_called_once_with(default={})
-
-    def test_get_keyboard_layouts_no_layouts(self):
-        """
-        Test that `get_keyboard_layouts` returns default value
-        if XBLOCK_SETTINGS include customizations for Skytap XBlock,
-        but do not specify keyboard layouts.
-        """
-        xblock_settings = {
-            "other": {},
-            "options": {},
-        }
-        self.block.get_xblock_settings = Mock(return_value=xblock_settings)
-        self.assertEqual(self.block.get_keyboard_layouts(), DEFAULT_KEYBOARD_LAYOUTS)
-        self.block.get_xblock_settings.assert_called_once_with(default={})
-
-    def test_get_keyboard_layouts(self):
-        """
-        Test that `get_keyboard_layouts` returns keyboard layouts as defined in XBLOCK_SETTINGS.
-        """
-        self.block.get_xblock_settings = Mock(return_value=XBLOCK_SETTINGS)
-        self.assertEqual(self.block.get_keyboard_layouts(), XBLOCK_SETTINGS["keyboard_layouts"])
-        self.block.get_xblock_settings.assert_called_once_with(default={})
-
-    def test_sorted_keyboard_layouts(self):
-        """
-        Test that `sorted_keyboard_layouts` sorts keyboard layouts by language name.
-        """
-        expected_keyboard_layouts = [
-            ("fi", "Finnish"),
-            ("fr", "French"),
-            ("de", "German"),
-            ("de-ch", "German-Switzerland"),
-            ("es", "Spanish"),
-        ]
-        self.block.get_xblock_settings = Mock(return_value=XBLOCK_SETTINGS)
-        self.assertEqual(self.block.sorted_keyboard_layouts, expected_keyboard_layouts)
 
     @ddt.unpack
     @ddt.data(

--- a/xblock_skytap/public/js/src/skytap.js
+++ b/xblock_skytap/public/js/src/skytap.js
@@ -21,8 +21,7 @@ function SkytapXBlock(runtime, element) {
     launchButton.on('click', function(e) {
         e.preventDefault();
 
-        var handlerUrl = runtime.handlerUrl(element, 'launch'),
-            keyboardLayout = launchForm.find('select').val();
+        var handlerUrl = runtime.handlerUrl(element, 'launch');
 
         if (launchXHR) {
             launchXHR.abort();
@@ -31,7 +30,7 @@ function SkytapXBlock(runtime, element) {
         launchSpinner.show();
         launchButton.prop('disabled', true);
 
-        launchXHR = $.post(handlerUrl, JSON.stringify(keyboardLayout))
+        launchXHR = $.post(handlerUrl, JSON.stringify({}))
             .success(function(response) {
                 var url = response.sharing_portal_url;
 

--- a/xblock_skytap/templates/skytap.html
+++ b/xblock_skytap/templates/skytap.html
@@ -2,19 +2,6 @@
 <div class="skytap-block">
   <h3>{% trans "Open the Exercise Environment Portal" %}</h3>
   <form class="skytap-launch-form">
-    <div>
-      <label>
-        <span>{% trans "Select your preferred keyboard layout" %}:</span>
-        <select name="keyboard_layout">
-          {% for language_code, language_name in keyboard_layouts %}
-            <option value="{{ language_code }}"
-                    {% if language_code == preferred_keyboard_layout %}selected{% endif %}>
-              {{ language_name }}
-            </option>
-          {% endfor %}
-        </select>
-      </label>
-    </div>
     <div class="skytap-action">
       <button type="button" class="skytap-launch">
         {% trans "Open" %}


### PR DESCRIPTION
This PR removes the keyboard layout field from the xblock.

**Screenshots**: 
<img width="952" alt="screen shot 2018-06-15 at 2 01 54 am" src="https://user-images.githubusercontent.com/9654006/41438263-26149d10-7040-11e8-88b7-98fda4781f4a.png">

(note that the keyboard layout drop down is missing)

**Testing instructions**:
detailed testing instructions here:
https://github.com/open-craft/xblock-skytap/pull/3
and 
https://github.com/open-craft/xblock-skytap/pull/6

Specific to this PR:
The keyboard selection field should not be visible.


**Reviewers**
- [x] (@itsjeyd)
