### PR TITLE
SE-2670 - Adding Tox Tests for Different Python(35, 38) and Django(22, 30) Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,44 @@
 # xblock-skytap
+
+## What is it?
+
+An XBlock for integrating [Open edX](https://open.edx.org/) and [Skytap](https://www.skytap.com/).
+
+## Support
+
+| Open edX Release | Tag |
+|:-----------------|:---:|
+| Juniper | v0.2 |
+| Ironwood | v0.1 |
+
+## Install 
+
+See [edX Installing an XBlock](http://edx.readthedocs.io/projects/edx-installing-configuring-and-running/en/latest/configuration/install_xblock.html?highlight=install%20xblock)
+for details on how to install this XBlock on your Open edX instance.
+
+```python
+pip install "git+https://github.com/open-craft/xblock-skytap@master#egg=xblock-skytap"
+```
+
+## Testing
+
+The test suite uses `tox`, so install it into a virtualenv to run the tests:
+
+```bash
+pip install tox
+```
+
+Accordingly, all you need to do in the repo's directory is to run the following:
+
+```bash
+tox
+```
+
+## Installing on DevStack
+
+1. Start your *edX devstack*
+2. Once the *edX devstack* is up, run `make studio-shell`
+3. `source ../venvs/edxapp/bin/activate`
+4. `sudo -u edxapp /edx/bin/pip.edxapp install "git+https://github.com/open-craft/xblock-skytap@master#egg=xblock-skytap"`
+5. `docker-compose restart studio`
+6. Repeat steps 2 till 5 using `lms` instead of `studio`, ei. `make lms-shell` and `docker-compose restart lms`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## What is it?
 
-An XBlock for integrating [Open edX](https://open.edx.org/) and [Skytap](https://www.skytap.com/).
+An XBlock for integrating [Open edX](https://open.edx.org/) and [Skytap](https://www.skytap.com/). 
+Our client uses this XBlock to create virtual machines so learners can practice what they are learning in the course.
 
 ## Support
 
@@ -38,7 +39,6 @@ tox
 
 1. Start your *edX devstack*
 2. Once the *edX devstack* is up, run `make studio-shell`
-3. `source ../venvs/edxapp/bin/activate`
 4. `sudo -u edxapp /edx/bin/pip.edxapp install "git+https://github.com/open-craft/xblock-skytap@master#egg=xblock-skytap"`
-5. `docker-compose restart studio`
-6. Repeat steps 2 till 5 using `lms` instead of `studio`, ei. `make lms-shell` and `docker-compose restart lms`.
+5. Exit the shell and run `make studio-restart`
+6. Repeat steps 2 till 5 using `lms` instead of `studio`, ei. `make lms-shell` and `make lms-restart`.

--- a/circle.yml
+++ b/circle.yml
@@ -5,16 +5,22 @@ jobs:
       - image: circleci/python:3.8.0
     steps:
       - checkout
-      - restore_cache:
-          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
+      - run:
+          name: Install Python 3.5
+          command: |
+            sudo apt-get update
+            sudo apt-get install build-essential libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev
+            cd /usr/src
+            sudo wget https://www.python.org/ftp/python/3.5.9/Python-3.5.9.tgz
+            sudo tar xzf Python-3.5.9.tgz
+            cd Python-3.5.9
+            sudo ./configure --enable-optimizations
+            sudo make altinstall
+            cd ~
       - run:
           name: Install tox
           command: |
-            pip install tox
-      - save_cache:
-          key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
-          paths:
-            - "venv"
+            sudo pip install tox
       - run:
           name: Run tests
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -2,26 +2,15 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/python:2.7.14-browsers
+      - image: circleci/python:3.8.0
     steps:
       - checkout
       - restore_cache:
           key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
       - run:
-          name: Install Python deps in a venv
+          name: Install tox
           command: |
-            virtualenv venv
-            . venv/bin/activate
-            pip install -U pip wheel
-            # Temporarily pin setuptools to a specific version.
-            # See commit message of https://github.com/open-craft/problem-builder/commit/51277a34fb426724616618c1afdb893ab2de4c6b for more info:
-            pip install setuptools==24.3.1
-            pip install -r requirements.txt
-            pip install -r test-requirements.txt
-            pip install -r venv/src/xblock-sdk/requirements/base.txt
-            pip install -r venv/src/xblock-sdk/requirements/test.txt
-            pip install -e .
-            mkdir var
+            pip install tox
       - save_cache:
           key: dependencies-{{ checksum "circle.yml" }}-{{ checksum "requirements.txt" }}-{{ checksum "test-requirements.txt" }}
           paths:
@@ -29,9 +18,4 @@ jobs:
       - run:
           name: Run tests
           command: |
-            . venv/bin/activate
-            pep8 xblock_skytap --max-line-length=120;
-            pep8 tests --max-line-length=120;
-            pylint xblock_skytap --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable;
-            pylint tests --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable;
-            SELENIUM_BROWSER=chrome python run_tests.py
+            tox

--- a/pylintrc
+++ b/pylintrc
@@ -3,6 +3,7 @@ reports=no
 
 [FORMAT]
 max-line-length=120
+max-parents=20
 
 [OPTIONS]
 good-names=_,loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/edx/xblock-utils.git@v1.0.4#egg=xblock-utils==1.0.4
+git+https://github.com/edx/xblock-utils.git@2.1.1#egg=xblock-utils==2.1.1
 -e .

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='xblock-skytap',
-    version='0.1',
+    version='0.2',
     description='Skytap XBlock',
     packages=['xblock_skytap'],
     install_requires=[

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
--e git+https://github.com/edx/xblock-sdk.git@v0.1.3#egg=xblock-sdk==0.1.3
-httpretty==0.8.14
+-e git+https://github.com/edx/xblock-sdk.git@0.2.0#egg=xblock-sdk==0.2.0
+httpretty==1.0.2

--- a/tests/integration/test_skytap.py
+++ b/tests/integration/test_skytap.py
@@ -30,9 +30,12 @@ class TestSkytap(StudioEditableBaseTest):
     default_css_selector = "div.skytap-block"
 
     def load_scenario(self, path, params=None):
+        """
+        Loads XBlock Scenario
+        """
         scenario = loader.render_template(path, params)
         self.set_scenario_xml(scenario)
-        self.element = self.go_to_view("student_view")
+        self.element = self.go_to_view("student_view")  # pylint: disable=attribute-defined-outside-init
 
     def refresh_page(self):
         """
@@ -86,7 +89,7 @@ class TestSkytap(StudioEditableBaseTest):
         launch_button = self.find_launch_button(0)
         spinner = self.find_spinner()
 
-        def mock_post(*args, **kwargs):
+        def mock_post(*args, **kwargs):  # pylint: disable=unused-argument
             """
             Function to use for patching `requests.post`.
 

--- a/tests/integration/test_skytap.py
+++ b/tests/integration/test_skytap.py
@@ -6,7 +6,7 @@ Integration tests for the Skytap XBlock.
 
 import time
 
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from selenium.webdriver.support.ui import WebDriverWait
 

--- a/tests/unit/mixins/boomi.py
+++ b/tests/unit/mixins/boomi.py
@@ -27,9 +27,6 @@ class CreateVmMockMixin(unittest.TestCase):
     Mocks for 'createVm' Boomi endpoint responses.
     """
 
-    def setUp(self):
-        super(CreateVmMockMixin, self).setUp()
-
     @staticmethod
     def mock_createvm(mock_url, sharing_portal_url="https://skytap.example.com/sharing/portal/url"):
         """

--- a/tests/unit/test_skytap.py
+++ b/tests/unit/test_skytap.py
@@ -8,7 +8,7 @@ import json
 
 import ddt
 import httpretty
-from mock import Mock
+from unittest.mock import Mock
 
 from xblock.field_data import DictFieldData
 
@@ -55,7 +55,7 @@ class TestSkytap(CreateVmMockMixin):
         """
         Helper method for calling the launch method and asserting an expected response dict.
         """
-        response = self.block.launch(request=Mock(method='POST', body=json.dumps('de')))
+        response = self.block.launch(request=Mock(method='POST', body=json.dumps('de').encode()))
 
         self.assertEqual(response.status_code, code)
         self.assertDictEqual(response.json, expected)

--- a/tests/unit/test_skytap.py
+++ b/tests/unit/test_skytap.py
@@ -5,10 +5,10 @@ Unit tests for the Skytap XBlock.
 # Imports ###########################################################
 
 import json
+from unittest.mock import Mock
 
 import ddt
 import httpretty
-from unittest.mock import Mock
 
 from xblock.field_data import DictFieldData
 
@@ -55,10 +55,10 @@ class TestSkytap(CreateVmMockMixin):
         """
         Helper method for calling the launch method and asserting an expected response dict.
         """
-        response = self.block.launch(request=Mock(method='POST', body=json.dumps('de').encode()))
+        response = self.block.launch(request=Mock(method='POST', body=json.dumps('de').encode()))  # pylint: disable=unexpected-keyword-arg,no-value-for-parameter
 
-        self.assertEqual(response.status_code, code)
-        self.assertDictEqual(response.json, expected)
+        self.assertEqual(response.status_code, code)  # pylint: disable=no-member
+        self.assertDictEqual(response.json, expected)  # pylint: disable=no-member
 
     @ddt.unpack
     @ddt.data(

--- a/tox.ini
+++ b/tox.ini
@@ -31,8 +31,12 @@ commands =
 
 [testenv:py38-quality]
 deps =
+    -rtest-requirements.txt
     requests
     pylint
 
 commands =
-    pylint --rcfile=pylintrc xblock_skytap
+    pip install -r {envdir}/src/xblock-sdk/requirements/base.txt
+    pip install -r {envdir}/src/xblock-sdk/requirements/test.txt
+
+    pylint --rcfile=pylintrc xblock_skytap tests

--- a/tox.ini
+++ b/tox.ini
@@ -10,15 +10,23 @@ envlist = py{35}-django{22}, py{38}-django{22,30}, py38-quality
 setenv =
     SELENIUM_BROWSER=chrome
 
+passenv =
+    *
+
 deps =
     -rtest-requirements.txt
     django22: Django==2.2.13
     django30: Django>=3.0,<3.1
 
-commands =
+commands_pre =
     pip install -r {envdir}/src/xblock-sdk/requirements/base.txt
     pip install -r {envdir}/src/xblock-sdk/requirements/test.txt
-    
+
+    # upgrade both bok-choy and selenium to avoid BrokenPromise Error
+    # caused due to deprecated chromeOptions issue
+    pip install selenium==3.141.0 bok-choy==1.1.1
+
+commands =
     python run_tests.py
 
 [testenv:py38-quality]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py{35}-django{22}, py{38}-django{22,30}
+
+[testenv]
+setenv =
+    SELENIUM_BROWSER=chrome
+
+deps =
+    -rtest-requirements.txt
+    django22: Django==2.2.13
+    django30: Django>=3.0,<3.1
+
+commands =
+    pip install -r {envdir}/src/xblock-sdk/requirements/base.txt
+    pip install -r {envdir}/src/xblock-sdk/requirements/test.txt
+    
+    python run_tests.py

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 [tox]
 envlist = py{35}-django{22}, py{38}-django{22,30}, py38-quality
 
-[testenv]
+[testenv:pyNM-djangoNM]
 setenv =
     SELENIUM_BROWSER=chrome
 

--- a/tox.ini
+++ b/tox.ini
@@ -31,11 +31,8 @@ commands =
 
 [testenv:py38-quality]
 deps =
-    pep8
+    requests
     pylint
 
 commands =
-    pep8 xblock_skytap --max-line-length=120
-    pep8 tests --max-line-length=120
-    pylint xblock_skytap --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable
-    pylint tests --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable
+    pylint --rcfile=pylintrc xblock_skytap

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{35}-django{22}, py{38}-django{22,30}
+envlist = py{35}-django{22}, py{38}-django{22,30}, py38-quality
 
 [testenv]
 setenv =
@@ -20,3 +20,14 @@ commands =
     pip install -r {envdir}/src/xblock-sdk/requirements/test.txt
     
     python run_tests.py
+
+[testenv:py38-quality]
+deps =
+    pep8
+    pylint
+
+commands =
+    pep8 xblock_skytap --max-line-length=120
+    pep8 tests --max-line-length=120
+    pylint xblock_skytap --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable
+    pylint tests --disable=all --enable=function-redefined,undefined-variable,unused-import,unused-variable

--- a/xblock_skytap/__init__.py
+++ b/xblock_skytap/__init__.py
@@ -1,1 +1,5 @@
+"""
+Imports SkytabXBlock
+"""
+
 from .skytap import SkytapXBlock

--- a/xblock_skytap/exceptions.py
+++ b/xblock_skytap/exceptions.py
@@ -7,11 +7,8 @@ class BoomiConfigurationMissingError(RuntimeError):
     """
     Raised if XBLOCK_SETTINGS for Skytap XBlock do not contain "boomi_configuration" entry.
     """
-    pass
-
 
 class BoomiConfigurationInvalidError(RuntimeError):
     """
     Raised if "boomi_configuration" for Skytap XBlock is missing one or more relevant entries.
     """
-    pass

--- a/xblock_skytap/skytap.py
+++ b/xblock_skytap/skytap.py
@@ -14,7 +14,7 @@ for opening the sharing portal link in a new browser tab.
 from __future__ import absolute_import
 import base64
 import logging
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 import requests
 from simplejson import JSONDecodeError

--- a/xblock_skytap/skytap.py
+++ b/xblock_skytap/skytap.py
@@ -12,6 +12,7 @@ for opening the sharing portal link in a new browser tab.
 # Imports ###########################################################
 
 from __future__ import absolute_import
+
 import base64
 import logging
 from urllib.parse import urljoin
@@ -26,9 +27,9 @@ from xblockutils.resources import ResourceLoader
 from xblockutils.settings import XBlockWithSettingsMixin
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 
-from .exceptions import BoomiConfigurationInvalidError, BoomiConfigurationMissingError
+from .exceptions import (BoomiConfigurationInvalidError,
+                         BoomiConfigurationMissingError)
 from .utils import _  # pylint: disable=unused-import
-
 
 # Globals ###########################################################
 
@@ -151,7 +152,7 @@ class SkytapXBlock(StudioEditableXBlockMixin, XBlockWithSettingsMixin, XBlock):
         raise JsonHandlerError(500, message)
 
     @XBlock.json_handler
-    def launch(self, data, suffix=""):
+    def launch(self, data, suffix=""):  # pylint: disable=unused-argument
         """
         Launch Skytap environment and return the resulting sharing portal URL.
         """


### PR DESCRIPTION
Adds tox automation in order to run the tests on different python versions (35, 38) and django versions (22, 30).

**JIRA tickets**: SE-2670

**Merge deadline**: None

**Testing instructions**:

1. Make sure you have `tox` installed through `pip`.
2. Run the tests through `tox`. 

**Reviewers**
- [ ] @pomegranited 